### PR TITLE
chore: update Google Play Billing Library to version 5.2.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,5 +26,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.android.billingclient:billing:4.0.0'
+    implementation 'com.android.billingclient:billing:5.2.1'
 }


### PR DESCRIPTION
# Summary

Update Google Play Billing Library to version 5.2.1.

See https://developer.android.com/google/play/billing/deprecation-faq.